### PR TITLE
Filter published posts, add blog image fallbacks

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -13,7 +13,7 @@ from django.urls import reverse, reverse_lazy
 from django.views.generic import DetailView, ListView, TemplateView, UpdateView
 from djstripe import models as djstripe_models
 
-from core.choices import Language, ProfileStates, ProjectPageType
+from core.choices import BlogPostStatus, Language, ProfileStates, ProjectPageType
 from core.forms import ProfileUpdateForm, ProjectScanForm
 from core.models import (
     BlogPost,
@@ -181,6 +181,9 @@ class BlogPostView(DetailView):
     model = BlogPost
     template_name = "blog/blog_post.html"
     context_object_name = "blog_post"
+
+    def get_queryset(self):
+        return BlogPost.objects.filter(status=BlogPostStatus.PUBLISHED)
 
 
 class ProjectDetailView(LoginRequiredMixin, DetailView):

--- a/frontend/templates/blog/blog_post.html
+++ b/frontend/templates/blog/blog_post.html
@@ -13,7 +13,13 @@
 <meta property="og:title" content="{{ blog_post.title }}" />
 <meta property="og:url" content="https://{{ request.get_host }}{{ blog_post.get_absolute_url }}" />
 <meta property="og:description" content="{{ blog_post.description }}" />
-<meta property="og:image" content="https://osig.app/g?site=x&style=base&font=markerfelt&title={{ blog_post.title }} | Marketing Agents Blog&subtitle={{ blog_post.description }}&image_url={{ blog_post.image.url }}" />
+{% if blog_post.image %}
+  <meta property="og:image" content="https://osig.app/g?site=x&style=base&font=markerfelt&title={{ blog_post.title }} | Marketing Agents Blog&subtitle={{ blog_post.description }}&image_url={{ blog_post.image.url }}" />
+{% elif blog_post.icon %}
+  <meta property="og:image" content="https://osig.app/g?site=x&style=base&font=markerfelt&title={{ blog_post.title }} | Marketing Agents Blog&subtitle={{ blog_post.description }}&image_url={{ blog_post.icon.url }}" />
+{% else %}
+  <meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+{% endif %}
 <meta property="og:locale" content="en_US" />
 
 <meta name="twitter:card" content="summary_large_image" />
@@ -21,7 +27,13 @@
 <meta name="twitter:site" content="@rasulkireev" />
 <meta name="twitter:title" content="{{ blog_post.title }}" />
 <meta name="twitter:description" content="{{ blog_post.description }}" />
-<meta name="twitter:image" content="https://osig.app/g?site=x&style=base&font=markerfelt&title={{ blog_post.title }} | Marketing Agents Blog&subtitle={{ blog_post.description }}&image_url={{ blog_post.image.url }}" />
+{% if blog_post.image %}
+  <meta name="twitter:image" content="https://osig.app/g?site=x&style=base&font=markerfelt&title={{ blog_post.title }} | Marketing Agents Blog&subtitle={{ blog_post.description }}&image_url={{ blog_post.image.url }}" />
+{% elif blog_post.icon %}
+  <meta name="twitter:image" content="https://osig.app/g?site=x&style=base&font=markerfelt&title={{ blog_post.title }} | Marketing Agents Blog&subtitle={{ blog_post.description }}&image_url={{ blog_post.icon.url }}" />
+{% else %}
+  <meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+{% endif %}
 {% endblock meta %}
 
 {% block content %}
@@ -43,7 +55,13 @@
     "@type": "BlogPosting",
     "headline": "{{ blog_post.title }}",
     "description": "{{ blog_post.description }}",
-    "image": "https://osig.app/g?site=x&style=base&font=markerfelt&title={{ blog_post.title }} | Marketing Agents Blog&subtitle={{ blog_post.description }}&image_url={{ blog_post.image.url }}",
+    {% if blog_post.image %}
+      "image": "https://osig.app/g?site=x&style=base&font=markerfelt&title={{ blog_post.title }} | Marketing Agents Blog&subtitle={{ blog_post.description }}&image_url={{ blog_post.image.url }}",
+    {% elif blog_post.icon %}
+      "image": "https://osig.app/g?site=x&style=base&font=markerfelt&title={{ blog_post.title }} | Marketing Agents Blog&subtitle={{ blog_post.description }}&image_url={{ blog_post.icon.url }}",
+    {% else %}
+      "image": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}",
+    {% endif %}
     "url": "https://{{ request.get_host }}{{ blog_post.get_absolute_url }}",
     "datePublished": "{{ blog_post.created_at|date:'c' }}",
     "dateModified": "{{ blog_post.updated_at|date:'c' }}",

--- a/frontend/templates/blog/blog_posts.html
+++ b/frontend/templates/blog/blog_posts.html
@@ -32,9 +32,6 @@
         {% for post in blog_posts %}
           <a href="{{ post.get_absolute_url }}" class="block rounded-lg transition duration-150 ease-in-out hover:bg-gray-100">
             <article class="flex items-start p-4">
-              {% if post.icon %}
-                <img src="{{ post.icon.url }}" alt="{{ post.title }}" class="object-cover flex-shrink-0 mr-4 w-24 h-24 rounded-lg">
-              {% endif %}
               <div>
                 <h2 class="mb-2 text-2xl font-semibold text-gray-900">{{ post.title }}</h2>
                 <p class="text-gray-600">{{ post.description }}</p>


### PR DESCRIPTION
This commit introduces two main enhancements to the blog functionality:

1.  **Published Post Filtering:** The `BlogPostView` (detail view) now filters blog posts to only display those marked with `BlogPostStatus.PUBLISHED`. This prevents users from accessing draft or otherwise unpublished posts directly.

2.  **Enhanced Meta Image Handling:** The `blog_post.html` template has been updated to provide a fallback mechanism for images used in OpenGraph, Twitter card, and JSON-LD metadata. The image selection order is now:
    - `blog_post.image`
    - `blog_post.icon` (if `image` is not present)
    - Default static logo (if neither `image` nor `icon` is present) This ensures that social sharing previews and search engine results always have an associated image.

Additionally, the display of `post.icon` has been removed from the main blog listing page (`blog_posts.html`). This change aims to improve the visual consistency or simplify the layout of the blog index.