### PR TITLE
Add AI blog post structure prompt

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -724,6 +724,13 @@ class BlogPostTitleSuggestion(BaseModel):
                 Make sure the content is formatted correctly with headings, paragraphs, and lists and links.
             """
 
+        @agent.system_prompt
+        def post_structure() -> str:
+            return """
+                - Don't include blogpost title in the content.
+                - Don't start with a header or a subheader. Start with plain text as intro, then add subheaders as you see fit.
+            """
+
         project_pages = [
             ProjectPageContext(
                 url=page.url,

--- a/core/schemas.py
+++ b/core/schemas.py
@@ -135,7 +135,7 @@ class TitleSuggestionContext(BaseModel):
 
 class TitleSuggestion(BaseModel):
     title: str = Field(description="SEO-optimized blog post title")
-    category: str = Field(description="Primary content category")
+    category: str = Field(description="Primary content category. Make sure it is under 50 characters.")
     target_keywords: list[str] = Field(description="Strategic SEO keywords to target")
     description: str = Field(
         description="Brief overview of why this title is a good fit for the project and why it might work well for the target audience"


### PR DESCRIPTION
Added a system prompt to the BlogPostTitleSuggestion agent to control the structure of generated blog post content.

This prompt instructs the agent not to include the title, not to start with a header, but to begin with plain text followed by headers. This improves the readability and integration of generated content.

Also updated the description for the `category` field in the TitleSuggestion schema to specify a maximum length of 50 characters. This provides clearer guidance for category generation.