### PR TITLE
Introduce post_title property and refactor blog views

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -803,6 +803,10 @@ class GeneratedBlogPost(BaseModel):
     def __str__(self):
         return f"{self.project.name}: {self.title.title}"
 
+    @property
+    def post_title(self):
+        return self.title.title
+
     def submit_blog_post_to_endpoint(self):
         project = self.project
         settings = AutoSubmittionSetting.objects.filter(project=project).order_by("-id").first()

--- a/core/urls.py
+++ b/core/urls.py
@@ -8,7 +8,7 @@ urlpatterns = [
     path("", views.HomeView.as_view(), name="home"),
     path("settings", views.UserSettingsView.as_view(), name="settings"),
     # blog
-    path("blog", views.BlogView.as_view(), name="blog_posts"),
+    path("blog/", views.BlogView.as_view(), name="blog_posts"),
     path("blog/<slug:slug>", views.BlogPostView.as_view(), name="blog_post"),
     # app
     path("api/", api.urls),

--- a/core/views.py
+++ b/core/views.py
@@ -177,14 +177,14 @@ class BlogView(ListView):
     template_name = "blog/blog_posts.html"
     context_object_name = "blog_posts"
 
+    def get_queryset(self):
+        return BlogPost.objects.filter(status=BlogPostStatus.PUBLISHED).order_by("-created_at")
+
 
 class BlogPostView(DetailView):
     model = BlogPost
     template_name = "blog/blog_post.html"
     context_object_name = "blog_post"
-
-    def get_queryset(self):
-        return BlogPost.objects.filter(status=BlogPostStatus.PUBLISHED).order_by("-created_at")
 
 
 class ProjectDetailView(LoginRequiredMixin, DetailView):

--- a/frontend/src/controllers/auto_submit_body_controller.js
+++ b/frontend/src/controllers/auto_submit_body_controller.js
@@ -78,7 +78,7 @@ document.addEventListener("DOMContentLoaded", function() {
     const datalist = document.createElement("datalist");
     datalist.id = "body-value-suggestions";
     datalist.innerHTML = `
-      <option value="{{ title }}"></option>
+      <option value="{{ post_title }}"></option>
       <option value="{{ description }}"></option>
       <option value="{{ slug }}"></option>
       <option value="{{ tags }}"></option>


### PR DESCRIPTION
Add `post_title` property to `GeneratedBlogPost` model. This property provides a clear alias for `title.title` which is used in frontend templates (like the auto-submission body template) to refer specifically to the generated blog post's title.

Update frontend `auto_submit_body_controller` to use `{{ post_title }}` in suggestion datalist for clarity and consistency with the new model property.

Add a trailing slash to the blog list URL (`/blog/`) for URL pattern consistency.

Move the `get_queryset` method from `BlogPostView` (DetailView) to `BlogView` (ListView). This corrects the view logic, as the queryset is relevant for filtering the list of blog posts shown on the blog index page, not for fetching a single post.