### PR TITLE
Refactor project scan error handling flow

### DIFF
--- a/core/model_utils.py
+++ b/core/model_utils.py
@@ -121,4 +121,4 @@ def get_markdown_content(url):
             error=str(e),
             url=url,
         )
-        return ("", "", "")
+        raise e


### PR DESCRIPTION
Refactors the `scan_project` API view to improve error handling and clarify the scan process flow.

The view now explicitly checks the success of content fetching before attempting project analysis. If content fetching fails, the project is deleted and a specific error is returned. If content fetching succeeds but analysis fails, the project is also deleted with a specific error message.

This change provides clearer feedback on why a project scan might fail (content access vs. analysis issue). The broad exception catch in the view was removed, relying on the explicit checks for method return values.

Additionally, `get_markdown_content` was updated to re-raise exceptions encountered during fetching rather than returning empty strings. This clarifies the function's error signaling contract.