### PR TITLE
Fix quotes in JSON-LD articleBody

### DIFF
--- a/core/templatetags/markdown_extras.py
+++ b/core/templatetags/markdown_extras.py
@@ -6,7 +6,7 @@ from django.utils.safestring import mark_safe
 register = template.Library()
 
 
-@register.filter()
+@register.filter
 @stringfilter
 def markdown(value):
     md_instance = md.Markdown(extensions=["tables"])
@@ -14,3 +14,9 @@ def markdown(value):
     html = md_instance.convert(value)
 
     return mark_safe(html)
+
+
+@register.filter
+@stringfilter
+def replace_quotes(value):
+    return value.replace('"', "'")

--- a/frontend/templates/blog/blog_post.html
+++ b/frontend/templates/blog/blog_post.html
@@ -78,6 +78,7 @@
         "url": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}"
       }
     },
+    "articleBody": "{{ blog_post.content|replace_quotes|safe }}",
     "mainEntityOfPage": {
       "@type": "WebPage",
       "@id": "https://{{ request.get_host }}{{ blog_post.get_absolute_url }}"


### PR DESCRIPTION
Add a new template filter `replace_quotes` that replaces double quotes (") with single quotes (').

Apply this filter to the `articleBody` property within the blog post's JSON-LD schema markup.

This change is necessary to prevent potential JSON parsing errors caused by unescaped double quotes present in the blog post content. Using single quotes avoids conflict with the surrounding double quotes used for the JSON string value.