### PR TITLE
Focus keyword suggestions on short-tail, prioritize volume

### DIFF
--- a/core/schemas.py
+++ b/core/schemas.py
@@ -34,8 +34,7 @@ class ProjectDetails(BaseModel):
     pain_points: str = Field(description="List of target audience challenges in markdown list format")
     product_usage: str = Field(description="List of common use cases in markdown list format")
     proposed_keywords: str = Field(
-        description="""Comma separated list of 10 long-tail and 10 short-tail
-        keywords you think this site would rank well for"""
+        description="""Comma separated list of 20 short-tail keywords you think this site would rank well for"""
     )
     links: str = Field(
         description="""List of relevant URLs in markdown list format.

--- a/frontend/src/controllers/keyword_trends_controller.js
+++ b/frontend/src/controllers/keyword_trends_controller.js
@@ -10,7 +10,7 @@ export default class extends Controller {
     this.renderAllGraphs();
     // Default sort on connect
     if (this.hasSortTarget) {
-      this.sortTarget.value = "created_desc";
+      this.sortTarget.value = "volume_desc";
       this.sortKeywords();
     }
   }

--- a/frontend/templates/agents/keywords-agent.html
+++ b/frontend/templates/agents/keywords-agent.html
@@ -58,10 +58,10 @@
               <div class="flex flex-col w-full sm:w-1/2">
                 <label for="sort-keywords" class="mb-1 text-sm font-medium text-pink-700">Sort By</label>
                 <select id="sort-keywords" class="px-2 py-2 w-full h-10 text-sm bg-white rounded-md border border-pink-200 focus:ring-pink-500 focus:border-pink-500" data-keyword-trends-target="sort" data-action="change->keyword-trends#sortKeywords">
-                  <option value="created_desc">Newest First</option>
-                  <option value="created_asc">Oldest First</option>
                   <option value="volume_desc">Volume (High to Low)</option>
                   <option value="volume_asc">Volume (Low to High)</option>
+                  <option value="created_desc">Newest First</option>
+                  <option value="created_asc">Oldest First</option>
                   <option value="competition_desc">Competition (High to Low)</option>
                   <option value="competition_asc">Competition (Low to High)</option>
                   <option value="cpc_desc">CPC (High to Low)</option>


### PR DESCRIPTION
Update the project details schema to request only 20 short-tail keywords instead of a mix of short and long-tail.

Modify the frontend controller to default the keyword results sort order to volume (high to low) on page load.

Reorder the sort options in the UI template dropdown to place volume options at the top.

This change focuses the initial keyword suggestions on potentially higher-volume terms and presents them sorted by volume by default, improving the immediate utility of the results for many users.