### PR TITLE
Include calling function in agent run logs

### DIFF
--- a/core/model_utils.py
+++ b/core/model_utils.py
@@ -41,7 +41,7 @@ def run_agent_synchronously(agent, input_string, deps=None, function_name="", mo
     with capture_run_messages() as messages:
         try:
             logger.info(
-                "[Run Agent Synchronously] Running agent",
+                f"[Run Agent Synchronously - {function_name}] Running agent",
                 messages=messages,
                 input_string=input_string,
                 deps=deps,

--- a/core/models.py
+++ b/core/models.py
@@ -483,6 +483,12 @@ class Project(BaseModel):
         return result.data
 
     def find_competitors(self):
+        logger.info(
+            "[Project - find_competitors] Finding competitors for project",
+            project_id=self.id,
+            project_name=self.name,
+        )
+
         model = OpenAIModel(
             "sonar",
             provider=OpenAIProvider(


### PR DESCRIPTION
Include the name of the calling function in the log message when using the `run_agent_synchronously` utility. This enhances traceability and debugging by making it clear which part of the codebase initiated the agent run.

Additionally, add an informational log message at the beginning of the `Project.find_competitors` method to indicate its start, including the project ID and name for context.

This change improves overall logging clarity and diagnostic capabilities within the core modules.